### PR TITLE
Add SPM12

### DIFF
--- a/src/docker/ants.py
+++ b/src/docker/ants.py
@@ -18,7 +18,7 @@ manage_pkgs = {'apt': {'install': ('apt-get update -qq && apt-get install -yq '
                        'remove': 'apt-get purge -y --auto-remove {pkgs}'},
                'yum': {'install': 'yum install -y -q {pkgs}',
                        # Trying to uninstall ca-certificates breaks things.
-                       'remove': 'yum remove $(echo "{pkgs}" | sed "s/ca-certificates//g")'},}
+                       'remove': 'yum remove -y -q $(echo "{pkgs}" | sed "s/ca-certificates//g")'},}
 
 
 class ANTs(object):

--- a/src/docker/spm.py
+++ b/src/docker/spm.py
@@ -1,0 +1,110 @@
+"""Add Dockerfile instructions to install SPM.
+
+Project website: http://www.fil.ion.ucl.ac.uk/spm/
+
+This script installs the standalone SPM, which requires MATLAB Compiler Runtime
+but does not require a MATLAB license.
+"""
+from __future__ import absolute_import, division, print_function
+
+from src.docker.utils import indent
+from src.utils import check_url, logger
+
+manage_pkgs = {'apt': {'install': ('apt-get update -qq && apt-get install -yq '
+                                   '--no-install-recommends {pkgs}'),
+                       'remove': 'apt-get purge -y --auto-remove {pkgs}'},
+               'yum': {'install': 'yum install -y -q {pkgs}',
+                       # Trying to uninstall ca-certificates breaks things.
+                       'remove': 'yum remove -y -q $(echo "{pkgs}" | sed "s/ca-certificates//g")'},}
+
+
+class SPM(object):
+    """Add Dockerfile instructions to install SPM. For now, only SPM12 and
+    MATLAB R2017a are supported.
+
+    Inspired by the Dockerfile at https://hub.docker.com/r/nipype/workshops/
+    `docker pull nipype/workshops:latest-complete`
+
+    Parameters
+    ----------
+    version : {12}
+        SPM version.
+    matlab_version : str
+        MATLAB version. For example, 'R2017a'.
+    pkg_manager : {'apt', 'yum'}
+        Linux package manager.
+    """
+    def __init__(self, version, matlab_version, pkg_manager):
+        self.version = str(version)
+        self.matlab_version = matlab_version
+        self.pkg_manager = pkg_manager
+
+        if self.version not in ['12'] or self.matlab_version not in ['R2017a']:
+            raise ValueError("Only SPM12 and MATLAB R2017a are supported.")
+
+        self.cmd = self._create_cmd()
+
+    def _create_cmd(self):
+        """Return full command to install MCR and standalone SPM."""
+        comment = ("#----------------------\n"
+                   "# Install MCR and SPM{}\n"
+                   "#----------------------".format(self.version))
+        chunks = [comment, self.install_mcr(), '', self.install_spm()]
+        return "\n".join(chunks)
+
+    def install_mcr(self):
+        """Return Dockerfile insructions to install MATLAB Compiler Runtime."""
+        comment = "# Install MATLAB Compiler Runtime"
+        mcr_url = ("https://www.mathworks.com/supportfiles/downloads/{ver}/"
+                   "deployment_files/{ver}/installers/glnxa64/"
+                   "MCR_{ver}_glnxa64_installer.zip"
+                   "".format(ver=self.matlab_version))
+        check_url(mcr_url)
+
+        workdir_cmd = "WORKDIR /opt"
+        cmd = ("deps='ca-certificates unzip wget'\n"
+               '&& {install}\n'
+               '&& echo "destinationFolder=/opt/mcr" > mcr_options.txt\n'
+               '&& echo "agreeToLicense=yes" >> mcr_options.txt\n'
+               '&& echo "outputFile=/tmp/matlabinstall_log" >> mcr_options.txt\n'
+               '&& echo "mode=silent" >> mcr_options.txt\n'
+               '&& mkdir -p matlab_installer\n'
+               '&& wget -qO matlab_installer/installer.zip {mcr_url}\n'
+               '&& unzip matlab_installer/installer.zip -d matlab_installer/\n'
+               '&& matlab_installer/install -inputFile /opt/mcr_options.txt\n'
+               '&& rm -rf matlab_installer mcr_options.txt\n'
+               ''.format(mcr_url=mcr_url, **manage_pkgs[self.pkg_manager]))
+        cmd = cmd.format(pkgs="$deps")
+        cmd = indent("RUN", cmd)
+        return '\n'.join((comment, workdir_cmd, cmd))
+
+    def install_spm(self):
+        """Return Dockerfile instructions to install standalone SPM."""
+        comment = "# Install standalone SPM"
+        spm_url = ("http://www.fil.ion.ucl.ac.uk/spm/download/restricted/"
+           "utopia/dev/spm{spm_ver}_latest_Linux_{matlab_ver}.zip"
+           "".format(spm_ver=self.version, matlab_ver=self.matlab_version))
+        check_url(spm_url)
+
+        workdir_cmd = "WORKDIR /opt"
+        cmd = ("deps='ca-certificates unzip wget'\n"
+               '&& wget -qO spm{ver}.zip {spm_url}\n'
+               '&& unzip spm{ver}.zip\n'
+               '&& rm -rf spm{ver}.zip /tmp/*\n'
+               '&& {remove}'
+               ''.format(spm_url=spm_url, ver=self.version,
+                         **manage_pkgs[self.pkg_manager]))
+        cmd = cmd.format(pkgs="$deps")
+        cmd = indent("RUN", cmd)
+
+        # TODO: older versions of MCR might not have the same directory
+        # structure. This works with MCR from MATLAB R2017a.
+        env_cmd = ('MATLABCMD="/opt/mcr/v92/toolbox/matlab"\n'
+                   'SPMMCRCMD="/opt/spm{ver}/run_spm{ver}.sh /opt/mcr/v92/ script"\n'
+                   'FORCE_SPMMCR=1\n'
+                   'LD_LIBRARY_PATH=/opt/mcr/v92/runtime/glnxa64:'
+                   '/opt/mcr/v92/bin/glnxa64:'
+                   '/opt/mcr/v92/sys/os/glnxa64:$LD_LIBRARY_PATH'
+                   ''.format(ver=self.version))
+        env_cmd = indent("ENV", env_cmd)
+        return '\n'.join((comment, workdir_cmd, cmd, env_cmd))

--- a/src/docker/tests/test_ants.py
+++ b/src/docker/tests/test_ants.py
@@ -96,7 +96,7 @@ class TestANTs(object):
                 "    && mkdir -p /opt/ants \\\n"
                 "    && mv bin/* /opt/ants && mv ../ANTs/Scripts/* /opt/ants \\\n"
                 "    && cd /tmp && rm -rf ants-build \\\n"
-                '    && yum remove $(echo "$deps" | sed "s/ca-certificates//g")\n'
+                '    && yum remove -y -q $(echo "$deps" | sed "s/ca-certificates//g")\n'
                 "ENV ANTSPATH=/opt/ants\n"
                 "ENV PATH=$ANTSPATH:$PATH")
         ants = ANTs(version='latest', pkg_manager='yum', use_binaries=False)


### PR DESCRIPTION
SPM12 can now be installed. Matlab Compiler Runtime is also installed (required to run SPM). `apt` and `yum` package managers are supported.

Tests are in progress.